### PR TITLE
Avoid Writing AppxSignature to BlockMap File

### DIFF
--- a/PrivateHeaders/APPX/File.h
+++ b/PrivateHeaders/APPX/File.h
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <errno.h>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 namespace facebook {


### PR DESCRIPTION
A line for the AppxSignature.p7x file was incorrectly being written to the BlockMap file for the Appx packages. This was causing errors while parsing the package upon upload to the Microsoft Store:
- Include <stdexcept> for c++11 compilation. 
- Avoid adding AppxSignature p7x to BlockMap file.