### PR TITLE
Work with msix or appx.

### DIFF
--- a/PrivateHeaders/APPX/ZIP.h
+++ b/PrivateHeaders/APPX/ZIP.h
@@ -186,12 +186,16 @@ namespace appx {
         }
     };
 
+    inline bool _EndsWith(const std::string &input, const std::string &suffix)
+    {
+        return (
+            suffix.size() < input.size() &&
+            std::equal(suffix.rbegin(), suffix.rend(), input.rbegin()));
+    }
+
     inline bool _IsAPPXFile(const std::string &inputFileName)
     {
-        const std::string suffix = ".appx";
-        return (
-            suffix.size() < inputFileName.size() &&
-            std::equal(suffix.rbegin(), suffix.rend(), inputFileName.rbegin()));
+        return _EndsWith(inputFileName, ".appx") || _EndsWith(inputFileName, ".msix");
     }
 
     // For each of the appx files that we store in appxbundle, there is a

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Prerequisites:
 * OpenSSL developer library
 * zlib developer library
 
+Installing prerequisites:
+
+    sudo apt-get install cmake
+    sudo apt-get install build-essential
+    sudo apt-get install libssl-dev
+    sudo apt-get install zlib1g-dev
+
 Supported build and host platforms and toolchains:
 
 * GNU/Linux with GCC 4.8.1 or GCC 4.9


### PR DESCRIPTION
Identify either .msix or .appx files as being an 'appx file', so that it will skip generating a bunch of entries in the block map file for the msix.